### PR TITLE
fix XrView vectors having unitialized XrStructureType

### DIFF
--- a/gl2gridOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2gridOXR/app/src/main/cpp/app_engine.cpp
@@ -97,7 +97,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2handtrackOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2handtrackOXR/app/src/main/cpp/app_engine.cpp
@@ -305,7 +305,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2hittestOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2hittestOXR/app/src/main/cpp/app_engine.cpp
@@ -301,7 +301,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2imguiOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2imguiOXR/app/src/main/cpp/app_engine.cpp
@@ -108,7 +108,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2inputOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2inputOXR/app/src/main/cpp/app_engine.cpp
@@ -301,7 +301,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2passthroughOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2passthroughOXR/app/src/main/cpp/app_engine.cpp
@@ -323,7 +323,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2soundOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2soundOXR/app/src/main/cpp/app_engine.cpp
@@ -319,7 +319,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2soundboardOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2soundboardOXR/app/src/main/cpp/app_engine.cpp
@@ -327,7 +327,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2teapotOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2teapotOXR/app/src/main/cpp/app_engine.cpp
@@ -104,7 +104,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2tri3dOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2tri3dOXR/app/src/main/cpp/app_engine.cpp
@@ -98,7 +98,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);

--- a/gl2triOXR/app/src/main/cpp/app_engine.cpp
+++ b/gl2triOXR/app/src/main/cpp/app_engine.cpp
@@ -97,7 +97,7 @@ AppEngine::RenderLayer(XrTime dpy_time,
     /* Acquire View Location */
     uint32_t viewCount = (uint32_t)m_viewSurface.size();
 
-    std::vector<XrView> views(viewCount);
+    std::vector<XrView> views(viewCount, {XR_TYPE_VIEW});
     oxr_locate_views (m_session, dpy_time, m_appSpace, &viewCount, views.data());
 
     layerViews.resize (viewCount);


### PR DESCRIPTION
https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrView.html clearly states that the type must be initialized to XR_TYPE_VIEW.